### PR TITLE
Hotfix: Image Classification

### DIFF
--- a/app/src/business_logic_layer/services/obstacle.service.ts
+++ b/app/src/business_logic_layer/services/obstacle.service.ts
@@ -26,7 +26,7 @@ export class ObstacleService {
    * @param {number} x - The x coordinate.
    * @param {number} y - The y coordinate.
    * @param {Buffer} fileBuffer - A buffer containing the image data.
-   * @returns {Promise<{ object: string }>} An object containing the classification data for the obstacle.
+   * @returns {Promise<{ object: string }>} An object containing the classification data for the obstacle, or "Unknown" if no label was found.
    * @throws {BadRequestError} If there is no active mowing session.
    */
   public async add(
@@ -39,9 +39,9 @@ export class ObstacleService {
 
     if (!activeSession) throw new BadRequestError('No active session found');
 
-    const object: string = await this.imageClassificationService.classifyImage(
-      fileBuffer,
-    );
+    const classification: string | null =
+      await this.imageClassificationService.classifyImage(fileBuffer);
+    const object = classification ? classification : 'Unknown';
 
     const fileUrl: string = await this.fileStorageService.upload(
       uuidv4(),

--- a/app/src/data_access_layer/services/image-classification.service.ts
+++ b/app/src/data_access_layer/services/image-classification.service.ts
@@ -13,10 +13,10 @@ export class ImageClassificationService {
   /**
    * Classify an image using the Vision API.
    * @param {Buffer} bufferData - The image data as a Buffer.
-   * @returns {Promise<string>} The classification label for the image.
+   * @returns {Promise<string>} The classification label for the image, or null if no label annotations are found.
    * @throws {NotFoundError} If no label annotations are found in the image.
    */
-  public async classifyImage(bufferData: Buffer): Promise<string> {
+  public async classifyImage(bufferData: Buffer): Promise<string | null> {
     const request = {
       image: {
         content: bufferData,
@@ -34,11 +34,9 @@ export class ImageClassificationService {
     if (labelAnnotations && labelAnnotations.length > 0) {
       const label: string | null | undefined = labelAnnotations[0].description;
 
-      if (!label) throw new NotFoundError('No labels detected');
-
+      if (!label) return null;
       return label;
     }
-
-    throw new NotFoundError('No labels detected');
+    return null;
   }
 }


### PR DESCRIPTION
Image classification returns null if no label is found instead of the old NotFoundError.

DAL Image classification returns null if no label is found instead of the old NotFoundError. The BLL returns either the classification or "Unknown" if no label was found.